### PR TITLE
Fixed spanish translation for multiple business days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `es` translation from `# día habiles` to `# días habiles`
+
 ## [1.0.5] - 2019-09-02
 
 ### Added

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,5 +1,5 @@
 {
-  "shippingEstimate-bd": "{timeAmount, plural, =0 {Mismo día} one {En # día hábil} other {En hasta # día hábiles}}",
+  "shippingEstimate-bd": "{timeAmount, plural, =0 {Mismo día} one {En # día hábil} other {En hasta # días hábiles}}",
   "shippingEstimate-d": "{timeAmount, plural, =0 {Mismo día} one {En # día} other {En hasta # días}}",
   "shippingEstimate-h": "{timeAmount, plural, =0 {Con entrega inmediata} one {En # hora} other {En hasta # horas}}",
   "shippingEstimate-m": "{timeAmount, plural, =0 {Con entrega inmediata} one {En # minuto} other {En hasta # minutos}}",

--- a/react/TranslateEstimate.test.js
+++ b/react/TranslateEstimate.test.js
@@ -73,7 +73,7 @@ describe('TranslateEstimate - Valid Values', () => {
         <TranslateEstimate shippingEstimate="3m" />
       )
 
-      const expectedLabel = 'In up to 3 minutes'
+      const expectedLabel = 'Up to 3 minutes'
 
       expect(getByText(expectedLabel).textContent).toBe(expectedLabel)
     })
@@ -107,7 +107,7 @@ describe('TranslateEstimate - Valid Values', () => {
         <TranslateEstimate shippingEstimate="3h" />
       )
 
-      const expectedLabel = 'In up to 3 hours'
+      const expectedLabel = 'Up to 3 hours'
 
       expect(getByText(expectedLabel).textContent).toBe(expectedLabel)
     })
@@ -141,7 +141,7 @@ describe('TranslateEstimate - Valid Values', () => {
         <TranslateEstimate shippingEstimate="3d" />
       )
 
-      const expectedLabel = 'In up to 3 days'
+      const expectedLabel = 'Up to 3 days'
 
       expect(getByText(expectedLabel).textContent).toBe(expectedLabel)
     })
@@ -175,7 +175,7 @@ describe('TranslateEstimate - Valid Values', () => {
         <TranslateEstimate shippingEstimate="3bd" />
       )
 
-      const expectedLabel = 'In up to 3 business days'
+      const expectedLabel = 'Up to 3 business days'
 
       expect(getByText(expectedLabel).textContent).toBe(expectedLabel)
     })


### PR DESCRIPTION
#### What is the purpose of this pull request?

### Fixed

- `es` translation from `# día habiles` to `# días habiles`


#### What problem is this solving?

Closes [story](https://app.clubhouse.io/vtex/story/18560/shipping-options-it-always-shows-day-singular-and-working-plural-no-matter-the-amount-of-days)

#### How should this be manually tested?
`yarn test`

#### Screenshots or example usage
n/a

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
