### PR TITLE
1.x: Remove changelog from vtexignore file

### DIFF
--- a/.vtexignore
+++ b/.vtexignore
@@ -7,4 +7,3 @@ src/
 .gitignore
 package.json
 README.md
-CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Remove `CHANGELOG.md` from `.vtexignore`.
 
 ## [1.1.2] - 2020-04-02
 ### Fixed


### PR DESCRIPTION
#### What is the purpose of this pull request?

Removes `CHANGELOG.md` entry from `.vtexignore`.

#### What problem is this solving?

With this, our bots can access the changelog and automatically post the release notes with this app changes.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.